### PR TITLE
[ai-generated] Update About Me and Experience sections

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -122,16 +122,34 @@
         />
         
         <h4 class="widget-title">About Me</h4>
-        <div class="content"><p>我是林志隆，目前有 3 年以上前端開發經驗，擅長獨立作業完成各項需求，對於新的事物總是充滿好奇，保持著自我學習的態度更精進</p></div>
+        <div class="content"><p>我是林志隆，擁有 5 年以上前後端開發經驗，具備獨立執行專案與需求開發的實力。我對新技術保持高度好奇，並持續透過自我學習精進技能。我擅長將 AI 工具融入工作流程與日常生活中以極大化效率，並享受透過多角化思考解決技術難題，致力於為團隊創造更高的價值。</p></div>
         <h4 class="widget-title">Experience</h4>
         <ul class="timeline">
           
+          <li>
+            <div class="direction-r">
+              <div class="flag-wrapper">
+                <span class="hexa"></span>
+                <span class="time-wrapper"
+                  ><span class="time">2024.03 ~ 2026.04</span></span
+                >
+              </div>
+              <div class="desc">
+                <h5>軟體工程師 (全端)</h5>
+                <br />
+                任職於：統一資訊股份有限公司
+                <br />
+                工作地點：台北市
+              </div>
+            </div>
+          </li>
+
           <li>
             <div class="direction-l">
               <div class="flag-wrapper">
                 <span class="hexa"></span>
                 <span class="time-wrapper"
-                  ><span class="time">2022.04 ~ 2023.10</span></span
+                  ><span class="time">2022.04 ~ 2023.12</span></span
                 >
               </div>
               <div class="desc">

--- a/index.html
+++ b/index.html
@@ -128,7 +128,7 @@
         class="img-fluid author-thumb-sm d-block mx-auto rounded-circle mb-4"
       />
       
-      <p><p>我是林志隆，目前有 3 年以上前端開發經驗，擅長獨立作業完成各項需求，對於新的事物總是充滿好奇，保持著自我學習的態度更精進</p></p>
+      <p><p>我是林志隆，擁有 5 年以上前後端開發經驗，具備獨立執行專案與需求開發的實力。我對新技術保持高度好奇，並持續透過自我學習精進技能。我擅長將 AI 工具融入工作流程與日常生活中以極大化效率，並享受透過多角化思考解決技術難題，致力於為團隊創造更高的價值。</p></p>
       <a
         id="knowMoreButton"
         href="https://ChrisLinOvO.github.io/about/"


### PR DESCRIPTION
## Changes

### About Me (both index.html and about/index.html)
- 改為「擁有 5 年以上前後端開發經驗，具備獨立執行專案與需求開發的實力」
- 新增「對新技術保持高度好奇」、「將 AI 工具融入工作流程與日常生活」、「多角化思考解決技術難題」等內容

### Experience
- 資拓宏宇: 延長至 2022.04 ~ 2023.12
- 統一資訊股份有限公司: 新增 2024.03 ~ 2026.04 全端工程師（台北市）

⚠️ Human review required — AI cannot self-merge.